### PR TITLE
Configure backup script and Workbench DB connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,11 +42,10 @@ services:
       PGID: 1000
       TZ: UTC
     volumes:
-      - workbench_config:/config
+      - ./workbench:/config
     ports:
       - "3001:3001"
     depends_on:
       - db
 volumes:
   db_data:
-  workbench_config:

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,9 +1,19 @@
 #!/bin/sh
 # Create a backup of the MySQL database used by the compose stack.
 # Usage: ./scripts/backup_db.sh
+
 set -e
+
 TIMESTAMP="$(date +"%Y%m%d_%H%M%S")"
 BACKUP_DIR="backups"
+DB_CONTAINER="${DB_CONTAINER:-db}"
+DB_USER="${DB_USERNAME:-root}"
+
 mkdir -p "$BACKUP_DIR"
-docker-compose exec -T db mysqldump -u root -ppassword app > "$BACKUP_DIR/db_$TIMESTAMP.sql"
+
+DB_PASSWORD="$(docker-compose exec -T "$DB_CONTAINER" printenv MYSQL_ROOT_PASSWORD | tr -d '\r')"
+DB_NAME="$(docker-compose exec -T "$DB_CONTAINER" printenv MYSQL_DATABASE | tr -d '\r')"
+
+docker-compose exec -T "$DB_CONTAINER" mysqldump -u "$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" > "$BACKUP_DIR/db_$TIMESTAMP.sql"
+
 echo "Backup stored in $BACKUP_DIR/db_$TIMESTAMP.sql"

--- a/workbench/.mysql/workbench/connections.xml
+++ b/workbench/.mysql/workbench/connections.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<data>
+  <value type="object" struct-name="db.MySQLConnection">
+    <link type="object" struct-name="db.ConnectionFolder">/</link>
+    <value type="string" key="name">Local DB</value>
+    <value type="string" key="driver">MySQL</value>
+    <value type="string" key="hostIdentifier">db</value>
+    <value type="int" key="port">3306</value>
+    <value type="string" key="userName">root</value>
+    <value type="string" key="schema">app</value>
+  </value>
+</data>


### PR DESCRIPTION
## Summary
- Connect backup script to MySQL service using container environment variables
- Mount Workbench config and preseed connection to compose database

## Testing
- `shellcheck scripts/backup_db.sh`


------
https://chatgpt.com/codex/tasks/task_e_6894517fffb083208d030b001596e364